### PR TITLE
do not modify share.Data in Decode

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -55,12 +55,14 @@ func Wrap(tb testing.TB) *Asserter {
 
 func (a *Asserter) AssertNoError(err error) {
 	if err != nil {
+		a.tb.Helper()
 		a.tb.Fatalf("expected no error; got %v", err)
 	}
 }
 
 func (a *Asserter) AssertDeepEqual(x, y interface{}) {
 	if !reflect.DeepEqual(x, y) {
+		a.tb.Helper()
 		a.tb.Fatalf("expected\n%#v\n%#v\nto be equal", x, y)
 	}
 }


### PR DESCRIPTION
Decode modified share.Data while correcting any errors in the content.
This causes problems when the initial Decode fails and needs to be
retried. It may try to fix the "actually correct data", because it
doesn't have enough information... and this ends up messing up the
second Decode, when there is enough information.

Instead, when the correction needs to fix the initial buffers it now
will allocate a new []byte. This correcting invalid data should be
rather rare. The caller could be more defensive with regards to
protecting the data, however, that would cause significant number of
copies on the caller side on the common path.

Note, it will still modify the shares slice provided, so the caller can
access any corrected data.

Overall there probably is a better API design that makes this behavior
more obvious.
